### PR TITLE
feat(search): 新增網路搜尋功能 (Tool Use)

### DIFF
--- a/a.txt
+++ b/a.txt
@@ -2,6 +2,26 @@ git add .
 git commit -m "data commit"
 git push
 
+# 1. 切換到 main 分支
+git checkout main
+
+# 2. 從遠端 GitHub 拉取最新的版本，確保與線上同步
+git pull origin main
+
+# 從最新的 main 分支建立一個新分支，並立即切換過去
+# 分支名稱應清楚說明其目的，例如：
+git checkout -b feature/add-web-search
+# 或者
+git checkout -b fix/xxx
+
+# 遵循好的 commit 格式，例如：
+git commit -m "feat(profile): 增加用戶頭像上傳功能"
+
+# -u 參數會將本地分支與遠端分支建立關聯，之後只需 git push
+git push -u origin feature/user-profile-page
+
+
+
 # 1. 切換回主分支
 git checkout main
 

--- a/cogs/chatgpt.py
+++ b/cogs/chatgpt.py
@@ -5,79 +5,138 @@ from discord import app_commands
 from openai import OpenAI
 from typing import Optional, Literal
 import logging
+import json
+
+# --- 新增：匯入搜尋工具 ---
+from duckduckgo_search import DDGS
 
 # --- 新增：從我們的新模組中匯入所有函式 ---
 from .utils import db_manager
 
-# 獲取日誌記錄器
 logger = logging.getLogger("discord_bot")
 
-# 預設設定值
 DEFAULT_SETTINGS = {
-    "model": "gpt-4-turbo",
+    "model": "gpt-4o", # 建議使用 gpt-4o，工具使用效果更好
     "remember_context": True,
-    "system_prompt": "請你之後的回應一律使用繁體中文。"
+    "system_prompt": "請你之後的回應一律使用繁體中文。",
+    "enable_search": False, # 預設關閉搜尋
 }
+
+# --- 新增：定義我們的搜尋工具函式 ---
+def web_search(query: str, max_results: int = 5) -> str:
+    """使用 DuckDuckGo 進行網路搜尋，並返回格式化的結果。"""
+    logger.info(f"執行網路搜尋，關鍵字：{query}")
+    try:
+        with DDGS() as ddgs:
+            results = list(ddgs.text(query, max_results=max_results))
+        if not results:
+            return "沒有找到相關的搜尋結果。"
+        # 將結果格式化為簡單的字串
+        return "\n\n".join([f"標題: {r['title']}\n連結: {r['href']}\n摘要: {r['body']}" for r in results])
+    except Exception as e:
+        logger.error(f"網路搜尋時發生錯誤: {e}")
+        return f"搜尋時發生錯誤: {e}"
 
 class ChatGPTCog(commands.Cog):
     def __init__(self, bot: commands.Bot):
         self.bot = bot
         self.client = OpenAI(api_key=os.getenv("OPENAI_API_KEY"))
         
-        # --- 修改：啟動時直接呼叫 db_manager 來初始化和載入快取 ---
         db_manager.init_db()
         self.listened_channel_ids_cache = db_manager.load_listened_channels_to_cache()
+        
+        # --- 新增：定義工具的規格，讓 OpenAI 知道有這個工具可用 ---
+        self.tools = [
+            {
+                "type": "function",
+                "function": {
+                    "name": "web_search",
+                    "description": "當你需要回答關於即時資訊、近期事件或任何你知識庫中沒有的特定主題時，使用這個工具進行網路搜尋。",
+                    "parameters": {
+                        "type": "object",
+                        "properties": {
+                            "query": {
+                                "type": "string",
+                                "description": "要搜尋的關鍵字或問題，例如：'2024年奧運主辦城市' 或 'Nvidia最新股價'。",
+                            },
+                        },
+                        "required": ["query"],
+                    },
+                },
+            }
+        ]
+        # 將函式名稱對應到真正的函式
+        self.available_functions = {"web_search": web_search}
 
-    # --- 核心對話邏輯 ---
-    async def _call_chatgpt_api(self, user_id: str, prompt: str, model: str, remember_context: bool) -> str:
-        # 組合給 API 的訊息列表
-        messages_for_api = []
+    # --- 修改：核心對話邏輯，加入工具使用迴圈 ---
+    async def _call_chatgpt_api(self, user_id: str, prompt: str, user_settings: dict) -> str:
+        model = user_settings["model"]
+        remember_context = user_settings["remember_context"]
+        enable_search = user_settings["enable_search"]
+        system_prompt = user_settings["system_prompt"]
+        
+        messages = []
         if remember_context:
-            user_settings = db_manager.get_user_settings(user_id, {**DEFAULT_SETTINGS, "system_prompt": self.bot.config.get("default_system_prompt", DEFAULT_SETTINGS["system_prompt"])})
-            system_prompt = user_settings["system_prompt"]
-            messages_for_api = db_manager.get_user_history_from_db(user_id, system_prompt)
-            messages_for_api.append({"role": "user", "content": prompt})
+            messages = db_manager.get_user_history_from_db(user_id, system_prompt)
         else:
-            # 如果不使用歷史紀錄，也從db獲取個人設定，若無則使用預設
-            user_settings = db_manager.get_user_settings(user_id, DEFAULT_SETTINGS)
-            messages_for_api = [
-                {"role": "system", "content": user_settings["system_prompt"]},
-                {"role": "user", "content": prompt}
-            ]
+            messages = [{"role": "system", "content": system_prompt}]
+        
+        messages.append({"role": "user", "content": prompt})
+        
+        # 最多允許2次工具呼叫，防止無限迴圈
+        for _ in range(3): 
+            response = self.client.chat.completions.create(
+                model=model,
+                messages=messages,
+                tools=self.tools if enable_search else None, # 如果使用者啟用搜尋，才提供工具
+                tool_choice="auto" if enable_search else None,
+            )
+            response_message = response.choices[0].message
+            tool_calls = response_message.tool_calls
 
-        # 呼叫 OpenAI API
-        response = self.client.chat.completions.create(model=model, messages=messages_for_api)
-        reply_content = response.choices[0].message.content.strip()
+            if not tool_calls:
+                # 沒有工具呼叫，直接返回結果
+                reply_content = response_message.content
+                if remember_context:
+                    db_manager.add_message_to_db(user_id, "user", prompt)
+                    db_manager.add_message_to_db(user_id, "assistant", reply_content, model_used=model)
+                return reply_content
 
-        # 如果啟用歷史紀錄，則儲存對話
-        if remember_context:
-            db_manager.add_message_to_db(user_id, "user", prompt)
-            db_manager.add_message_to_db(user_id, "assistant", reply_content, model_used=model)
-
-        return reply_content
+            # 有工具呼叫，執行工具
+            messages.append(response_message)  # 將助理的工具呼叫請求也加入歷史
+            for tool_call in tool_calls:
+                function_name = tool_call.function.name
+                function_to_call = self.available_functions[function_name]
+                function_args = json.loads(tool_call.function.arguments)
+                function_response = function_to_call(**function_args)
+                
+                # 將工具的執行結果加入歷史
+                messages.append({
+                    "tool_call_id": tool_call.id,
+                    "role": "tool",
+                    "name": function_name,
+                    "content": function_response,
+                })
+        
+        # 如果迴圈結束仍未獲得最終答案，返回一個提示訊息
+        return "模型在多次嘗試使用工具後仍無法給出最終回覆，請嘗試簡化您的問題。"
 
     # --- 事件監聽器 ---
     @commands.Cog.listener()
     async def on_message(self, message: discord.Message):
-        if message.author == self.bot.user or message.author.bot:
-            return
+        if message.author.bot: return
 
         is_dm = isinstance(message.channel, discord.DMChannel)
         is_in_listen_channel = hasattr(message.channel, 'id') and message.channel.id in self.listened_channel_ids_cache
 
-        if not is_dm and not is_in_listen_channel:
-            return
-        
-        if message.content.startswith(self.bot.command_prefix):
-            return
+        if not is_dm and not is_in_listen_channel: return
+        if message.content.startswith(self.bot.command_prefix): return
             
         prompt = message.content.strip()
-        if not prompt:
-            return
+        if not prompt: return
 
         user_id_str = str(message.author.id)
         
-        # 從資料庫獲取使用者設定
         default_prompt = self.bot.config.get("default_system_prompt", DEFAULT_SETTINGS['system_prompt'])
         user_settings = db_manager.get_user_settings(user_id_str, {**DEFAULT_SETTINGS, "system_prompt": default_prompt})
         
@@ -86,8 +145,7 @@ class ChatGPTCog(commands.Cog):
                 reply_content = await self._call_chatgpt_api(
                     user_id=user_id_str,
                     prompt=prompt,
-                    model=user_settings["model"],
-                    remember_context=user_settings["remember_context"]
+                    user_settings=user_settings
                 )
             await message.reply(reply_content)
         except Exception as e:
@@ -147,29 +205,37 @@ class ChatGPTCog(commands.Cog):
 
     # --- 其他指令 ---
     @app_commands.command(name="settings", description="設定你個人的對話偏好")
-    @app_commands.describe(model="【可選】設定你偏好的對話模型", remember_context="【可選】設定是否要啟用對話歷史紀錄", system_prompt="【可選】設定你對AI的個人化指示")
-    async def settings(self, interaction: discord.Interaction, model: Optional[Literal["gpt-4o", "gpt-4-turbo", "gpt-4", "gpt-3.5-turbo"]] = None, remember_context: Optional[bool] = None, system_prompt: Optional[str] = None):
+    @app_commands.describe(
+        model="【可選】設定你偏好的對話模型 (推薦gpt-4o)",
+        remember_context="【可選】設定是否要啟用對話歷史紀錄",
+        system_prompt="【可選】設定你對AI的個人化指示",
+        enable_search="【可選】設定是否允許AI自動上網搜尋"
+    )
+    async def settings(self, interaction: discord.Interaction, 
+                       model: Optional[Literal["gpt-4o", "gpt-4-turbo", "gpt-4", "gpt-3.5-turbo"]] = None, 
+                       remember_context: Optional[bool] = None, 
+                       system_prompt: Optional[str] = None,
+                       enable_search: Optional[bool] = None):
         await interaction.response.defer(ephemeral=True)
         user_id_str = str(interaction.user.id)
 
-        if model is not None:
-            db_manager.update_user_setting(user_id_str, "model", model)
-        if remember_context is not None:
-            db_manager.update_user_setting(user_id_str, "remember_context", remember_context)
-        if system_prompt is not None:
-            db_manager.update_user_setting(user_id_str, "system_prompt", system_prompt)
+        # 更新設定
+        if model is not None: db_manager.update_user_setting(user_id_str, "model", model)
+        if remember_context is not None: db_manager.update_user_setting(user_id_str, "remember_context", remember_context)
+        if system_prompt is not None: db_manager.update_user_setting(user_id_str, "system_prompt", system_prompt)
+        if enable_search is not None: db_manager.update_user_setting(user_id_str, "enable_search", enable_search)
 
+        # 顯示更新後的設定
         default_prompt = self.bot.config.get("default_system_prompt", DEFAULT_SETTINGS['system_prompt'])
         current_settings = db_manager.get_user_settings(user_id_str, {**DEFAULT_SETTINGS, "system_prompt": default_prompt})
         
-        embed = discord.Embed(title=f"{interaction.user.display_name} 的個人化設定", description="當您在監聽頻道或私訊中與我對話時，將會套用以下設定。", color=discord.Color.blue())
-        embed.add_field(name="🧠 使用模型 (model)", value=f"`{current_settings['model']}`", inline=False)
-        embed.add_field(name="💾 歷史紀錄 (remember_context)", value="✅ 已啟用" if current_settings['remember_context'] else "❌ 已停用", inline=False)
-        embed.add_field(name="📜 系統提示 (system_prompt)", value=f"```\n{current_settings['system_prompt']}\n```", inline=False)
-        embed.set_footer(text="若要修改，請在指令中直接給予新設定值。")
+        embed = discord.Embed(title=f"{interaction.user.display_name} 的個人化設定", color=discord.Color.blue())
+        embed.add_field(name="🧠 使用模型", value=f"`{current_settings['model']}`", inline=False)
+        embed.add_field(name="💾 歷史紀錄", value="✅ 已啟用" if current_settings['remember_context'] else "❌ 已停用", inline=False)
+        embed.add_field(name="🌐 自動搜尋", value="✅ 已啟用" if current_settings['enable_search'] else "❌ 已停用", inline=False)
+        embed.add_field(name="📜 系統提示", value=f"```\n{current_settings['system_prompt']}\n```", inline=False)
         await interaction.followup.send(embed=embed)
 
-    # --- 修正點 1：@app_backs.command -> @app_commands.command ---
     @app_commands.command(name="clear_my_chat_history", description="清除你個人所有與 ChatGPT 的對話歷史")
     async def clear_my_chat_history(self, interaction: discord.Interaction):
         try:
@@ -178,7 +244,7 @@ class ChatGPTCog(commands.Cog):
         except Exception as e:
             logger.error(f"清除使用者 {interaction.user.id} 的歷史紀錄時發生錯誤: {e}", exc_info=True)
             await interaction.response.send_message(f"❌ 清除歷史時發生錯誤 ({type(e).__name__})。", ephemeral=True)
-
+            
     @app_commands.command(name="view_user_history", description="查看特定使用者的 ChatGPT 對話歷史紀錄 (僅限擁有者)")
     @app_commands.describe(user="要查看紀錄的 Discord 使用者", count="要顯示的最近訊息數量 (預設 10，最多 50)")
     @commands.is_owner()
@@ -186,7 +252,6 @@ class ChatGPTCog(commands.Cog):
         await interaction.response.defer(ephemeral=True) 
         user_id_to_view = str(user.id)
         
-        # --- 修正點 2：self._get_raw... -> db_manager.get_raw... ---
         history_records = db_manager.get_raw_user_history_for_viewing(user_id_to_view, limit=count)
 
         if not history_records:
@@ -195,9 +260,8 @@ class ChatGPTCog(commands.Cog):
         
         formatted_entries = []
         for record in reversed(history_records):
-            # 確保 timestamp 是字串才進行分割
             timestamp_str = str(record["timestamp"])
-            formatted_ts = timestamp_str.split('.')[0] # 簡化時間顯示
+            formatted_ts = timestamp_str.split('.')[0]
             
             role = record["role"].upper()
             content = record["content"]

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,3 +4,4 @@ requests
 aiohttp
 pillow
 openai
+duckduckgo-searchadd-web-search


### PR DESCRIPTION
這是一次核心功能升級，透過整合 OpenAI 的 Tool Use (工具使用) 功能，賦予了機器人即時上網查詢資訊的能力，使其不再受限於訓練資料的知識截止日期。

### 🚀 新增功能

1.  **整合 Tool Use 框架**：
    * 重構了核心對話函式 `_call_chatgpt_api`，使其支援工具使用的多步驟呼叫流程。
    * 當 AI 判斷需要即時資訊時，它現在可以請求呼叫外部工具。

2.  **新增 `web_search` 工具**：
    * 使用 `duckduckgo-search` 函式庫來執行網路搜尋，此工具免費且無需申請 API 金鑰。
    * 搜尋結果會被格式化後，回傳給 AI 進行整理與回答。

### ✨ 功能增強

1.  **資料庫升級**：
    * 在 `user_settings` 資料表中新增了 `enable_search` 欄位，允許每個使用者獨立控制是否開啟此功能。

2.  **`/settings` 指令更新**：
    * 在設定指令中加入了 `enable_search` 的開關選項，讓使用者可以方便地啟用或關閉自動搜尋。

### ✅ 如何測試

1.  執行 `/settings enable_search:True` 來為自己開啟此功能。
2.  嘗試提問需要即時資訊的問題，例如：
    * 「今天高雄的天氣如何？」
    * 「Nvidia 目前的股價是多少？」
    * 「最近有什麼關於 AI 的大新聞？」
3.  觀察機器人的日誌，應能看到 `執行網路搜尋...` 的相關紀錄。