### PR TITLE
Fix database initialization when data directory missing

### DIFF
--- a/cogs/utils/db_manager.py
+++ b/cogs/utils/db_manager.py
@@ -2,15 +2,19 @@ import sqlite3
 import datetime
 import logging
 from typing import Optional
+from pathlib import Path
 
 logger = logging.getLogger("discord_bot")
 
 
-DB_PATH = "/data/user_chat_history.db" 
+DATA_DIR = Path(__file__).resolve().parents[2] / "data"
+DB_PATH = DATA_DIR / "user_chat_history.db"
 
 # --- 初始化函式 ---
 def init_db():
     """初始化所有資料庫表格"""
+    DATA_DIR.mkdir(parents=True, exist_ok=True)
+
     with sqlite3.connect(DB_PATH) as conn:
         cursor = conn.cursor()
         # 聊天歷史紀錄表格


### PR DESCRIPTION
## Summary
- ensure the SQLite database path lives inside the repository instead of an absolute /data folder
- create the data directory before attempting any connections so first-run initialization succeeds

## Testing
- python -m compileall cogs/utils/db_manager.py

------
https://chatgpt.com/codex/tasks/task_e_68d8fbfa7000832eab494d34965f991a